### PR TITLE
RF: mark flaky tests

### DIFF
--- a/data/create_an_account.py
+++ b/data/create_an_account.py
@@ -35,7 +35,7 @@ create_an_account_credentials = {
     "weak_password_2": "1234qwere",
     "medium_password": "1234qweRE",
     "strong_password": '1234qweREe',
-    "very_strong_password": '1234qweREewe'
+    # "very_strong_password": '1234qweREewe'
 }
 
 password_strength_msg = [

--- a/tests/test_forgot_your_password.py
+++ b/tests/test_forgot_your_password.py
@@ -202,6 +202,7 @@ class TestForgotYourPasswordFunctionality:
         assert error_message == forgot_your_password_errors['incorrect_captcha_msg'], \
             "The error message is incorrect or missing"
 
+    @pytest.mark.xfail(reason="Flaky behavior on CI")
     @allure.title('TC 17.01.25 Verify error on resetting My Password with empty email')
     def test_17_01_25_error_if_reset_my_password_with_empty_email(self, driver, forgot_psw_page):
         """Check error message on attempt to reset password with empty email field"""


### PR DESCRIPTION
- xfail test 17_01_25 error if reset my password  as flaky on CI (Ubuntu)
- skipped very_strong_password in data/create_an_account.py